### PR TITLE
Stop displaying site title and tagline in header

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,16 +10,16 @@
 <header class="site-header">
     <div class="container">
         
-        <!-- Logo o título -->
+        <!-- Logo (título y descripción ocultos) -->
         <div class="header-left">
             <?php
-            if (has_custom_logo()) {
+            if ( has_custom_logo() ) {
                 the_custom_logo();
             } else {
-        if ( get_theme_mod('mostrar_titulo_sitio', true) ) {
-            echo '<a href="' . esc_url(home_url('/')) . '" class="site-title">' . get_bloginfo('name') . '</a>';
-        }
-    }
+                // No se muestra el título del sitio ni la descripción corta.
+                // echo '<a href="' . esc_url( home_url( '/' ) ) . '" class="site-title">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
+                // echo '<p class="site-description">' . esc_html( get_bloginfo( 'description' ) ) . '</p>';
+            }
             ?>
         </div>
 


### PR DESCRIPTION
## Summary
- hide site title and tagline outputs in header
- retain custom logo and keep site title/tagline options available

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e15b475fc83339b349ca5ad67783f