### PR TITLE
feat(header): add customizable CTA and logo sizing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -28,3 +28,53 @@
 .partners-swiper img:hover {
     transform: scale(1.05);
 }
+
+/* === Header CTA button === */
+.btn-cta {
+    display: inline-block;
+    text-decoration: none;
+    font-weight: 600;
+    line-height: 1;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+}
+
+/* Variants */
+.btn-cta.is-filled {
+    background-color: var(--color-primary, #0073aa);
+    color: var(--color-on-primary, #fff);
+    border-color: var(--color-primary, #0073aa);
+}
+.btn-cta.is-outline {
+    background-color: transparent;
+    color: var(--color-primary, #0073aa);
+    border-color: var(--color-primary, #0073aa);
+}
+.btn-cta.is-ghost {
+    background-color: transparent;
+    color: var(--color-primary, #0073aa);
+}
+
+/* Shapes */
+.btn-cta.is-pill { border-radius: 9999px; }
+.btn-cta.is-rounded { border-radius: 8px; }
+.btn-cta.is-square { border-radius: 0; }
+
+/* Sizes */
+.btn-cta.is-sm { padding: 0.25rem 0.75rem; font-size: 0.875rem; }
+.btn-cta.is-md { padding: 0.5rem 1rem; font-size: 1rem; }
+.btn-cta.is-lg { padding: 0.75rem 1.5rem; font-size: 1.125rem; }
+
+/* Hover & focus */
+.btn-cta:hover { filter: brightness(0.9); }
+.btn-cta.is-outline:hover {
+    background-color: var(--color-primary, #0073aa);
+    color: var(--color-on-primary, #fff);
+}
+.btn-cta.is-ghost:hover {
+    background-color: rgba(0,0,0,0.05);
+}
+.btn-cta:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}

--- a/functions.php
+++ b/functions.php
@@ -238,6 +238,8 @@ function mi_tema_estilos() {
     wp_enqueue_style('mi-tema-style', get_stylesheet_uri(), array(), wp_get_theme()->get('Version'));
     wp_enqueue_style('mi-tema-google-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap', array(), null);
     wp_enqueue_style('swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css', array(), null);
+    // Main theme stylesheet for custom components.
+    wp_enqueue_style('veltia-main', get_template_directory_uri() . '/assets/css/main.css', array(), wp_get_theme()->get('Version'));
 }
 add_action('wp_enqueue_scripts', 'mi_tema_estilos');
 
@@ -253,7 +255,6 @@ add_action('wp_enqueue_scripts', 'mi_tema_scripts');
 // Enqueue assets for partners carousel
 function veltia_partners_assets() {
     if ( is_front_page() ) {
-        wp_enqueue_style( 'veltia-partners', get_template_directory_uri() . '/assets/css/main.css', array(), wp_get_theme()->get( 'Version' ) );
         wp_enqueue_script( 'veltia-partners', get_template_directory_uri() . '/assets/js/main.js', array( 'swiper-js' ), wp_get_theme()->get( 'Version' ), true );
     }
 }
@@ -372,3 +373,24 @@ function mi_tema_customize_menu_footer($wp_customize) {
     ));
 }
 add_action('customize_register', 'mi_tema_customize_menu_footer');
+
+// Load customizer options for CTA and logo.
+require_once get_template_directory() . '/inc/customizer.php';
+
+/**
+ * Add inline styles for logo dimensions based on Customizer settings.
+ */
+function veltia_custom_logo_css() {
+    $desktop = absint( get_theme_mod( 'logo_max_height_header_desktop', 56 ) );
+    $mobile  = absint( get_theme_mod( 'logo_max_height_header_mobile', 40 ) );
+    $width   = absint( get_theme_mod( 'logo_max_width_header', 200 ) );
+    $slider_h = absint( get_theme_mod( 'logo_max_height_slider', 120 ) );
+    $slider_w = absint( get_theme_mod( 'logo_max_width_slider', 300 ) );
+
+    $css  = ".site-header .custom-logo{max-height:{$desktop}px;max-width:{$width}px;}";
+    $css .= "@media (max-width:768px){.site-header .custom-logo{max-height:{$mobile}px;}}";
+    $css .= ".slider-logo{max-height:{$slider_h}px;max-width:{$slider_w}px;}";
+
+    wp_add_inline_style( 'veltia-main', $css );
+}
+add_action( 'wp_enqueue_scripts', 'veltia_custom_logo_css', 20 );

--- a/header.php
+++ b/header.php
@@ -38,9 +38,31 @@
             ?>
 
             <!-- Botón CTA -->
-            <?php if ( get_theme_mod('menu_cta_text') && get_theme_mod('menu_cta_url') ) : ?>
-                <a href="<?php echo esc_url(get_theme_mod('menu_cta_url')); ?>" class="menu-cta-button">
-                    <?php echo esc_html(get_theme_mod('menu_cta_text')); ?>
+            <?php if ( get_theme_mod( 'cta_enable' ) && get_theme_mod( 'cta_text' ) && get_theme_mod( 'cta_url' ) ) : ?>
+                <?php
+                $cta_classes = array( 'btn-cta' );
+                $cta_classes[] = 'is-' . get_theme_mod( 'cta_style_variant', 'filled' );
+                $cta_classes[] = 'is-' . get_theme_mod( 'cta_shape', 'pill' );
+                $cta_classes[] = 'is-' . get_theme_mod( 'cta_size', 'md' );
+                $cta_classes = array_map( 'sanitize_html_class', $cta_classes );
+                $cta_class_attr = implode( ' ', $cta_classes );
+
+                $cta_style = '';
+                $cta_bg    = get_theme_mod( 'cta_color_bg' );
+                $cta_text_color = get_theme_mod( 'cta_color_text' );
+                if ( $cta_bg ) {
+                    $cta_style .= 'background-color:' . esc_attr( $cta_bg ) . ';border-color:' . esc_attr( $cta_bg ) . ';';
+                }
+                if ( $cta_text_color ) {
+                    $cta_style .= 'color:' . esc_attr( $cta_text_color ) . ';';
+                }
+                $cta_style_attr = $cta_style ? ' style="' . esc_attr( $cta_style ) . '"' : '';
+
+                $cta_target = get_theme_mod( 'cta_target', '_self' );
+                $cta_target_attr = '_blank' === $cta_target ? ' target="_blank" rel="noopener"' : '';
+                ?>
+                <a href="<?php echo esc_url( get_theme_mod( 'cta_url' ) ); ?>" class="<?php echo esc_attr( $cta_class_attr ); ?>"<?php echo $cta_target_attr; ?><?php echo $cta_style_attr; ?> aria-label="<?php echo esc_attr( get_theme_mod( 'cta_text' ) ); ?>">
+                    <?php echo esc_html( get_theme_mod( 'cta_text' ) ); ?>
                 </a>
             <?php endif; ?>
         </nav>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Customizer options for header CTA and logo sizes.
+ *
+ * @package veltia-base
+ */
+
+/**
+ * Register customizer settings and controls.
+ *
+ * @param WP_Customize_Manager $wp_customize Customizer manager instance.
+ */
+function veltia_customize_register( $wp_customize ) {
+    // Header section.
+    $wp_customize->add_section(
+        'veltia_header_section',
+        array(
+            'title'    => __( 'Header', 'veltia-base' ),
+            'priority' => 30,
+        )
+    );
+
+    // CTA enable.
+    $wp_customize->add_setting(
+        'cta_enable',
+        array(
+            'default'           => false,
+            'sanitize_callback' => 'wp_validate_boolean',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_enable',
+        array(
+            'label'   => __( 'Enable CTA', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'checkbox',
+        )
+    );
+
+    // CTA text.
+    $wp_customize->add_setting(
+        'cta_text',
+        array(
+            'sanitize_callback' => 'sanitize_text_field',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_text',
+        array(
+            'label'   => __( 'CTA Text', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'text',
+        )
+    );
+
+    // CTA URL.
+    $wp_customize->add_setting(
+        'cta_url',
+        array(
+            'sanitize_callback' => 'esc_url_raw',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_url',
+        array(
+            'label'   => __( 'CTA URL', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'url',
+        )
+    );
+
+    // CTA target.
+    $wp_customize->add_setting(
+        'cta_target',
+        array(
+            'default'           => '_self',
+            'sanitize_callback' => 'veltia_sanitize_select',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_target',
+        array(
+            'label'   => __( 'Open link in', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'select',
+            'choices' => array(
+                '_self'  => __( 'Same tab', 'veltia-base' ),
+                '_blank' => __( 'New tab', 'veltia-base' ),
+            ),
+        )
+    );
+
+    // CTA style variant.
+    $wp_customize->add_setting(
+        'cta_style_variant',
+        array(
+            'default'           => 'filled',
+            'sanitize_callback' => 'veltia_sanitize_select',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_style_variant',
+        array(
+            'label'   => __( 'Style Variant', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'select',
+            'choices' => array(
+                'filled'  => __( 'Filled', 'veltia-base' ),
+                'outline' => __( 'Outline', 'veltia-base' ),
+                'ghost'   => __( 'Ghost', 'veltia-base' ),
+            ),
+        )
+    );
+
+    // CTA shape.
+    $wp_customize->add_setting(
+        'cta_shape',
+        array(
+            'default'           => 'pill',
+            'sanitize_callback' => 'veltia_sanitize_select',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_shape',
+        array(
+            'label'   => __( 'Shape', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'select',
+            'choices' => array(
+                'pill'    => __( 'Pill', 'veltia-base' ),
+                'rounded' => __( 'Rounded', 'veltia-base' ),
+                'square'  => __( 'Square', 'veltia-base' ),
+            ),
+        )
+    );
+
+    // CTA size.
+    $wp_customize->add_setting(
+        'cta_size',
+        array(
+            'default'           => 'md',
+            'sanitize_callback' => 'veltia_sanitize_select',
+        )
+    );
+    $wp_customize->add_control(
+        'cta_size',
+        array(
+            'label'   => __( 'Size', 'veltia-base' ),
+            'section' => 'veltia_header_section',
+            'type'    => 'select',
+            'choices' => array(
+                'sm' => __( 'Small', 'veltia-base' ),
+                'md' => __( 'Medium', 'veltia-base' ),
+                'lg' => __( 'Large', 'veltia-base' ),
+            ),
+        )
+    );
+
+    // CTA background color.
+    $wp_customize->add_setting(
+        'cta_color_bg',
+        array(
+            'sanitize_callback' => 'sanitize_hex_color',
+        )
+    );
+    $wp_customize->add_control(
+        new WP_Customize_Color_Control(
+            $wp_customize,
+            'cta_color_bg',
+            array(
+                'label'   => __( 'CTA Background', 'veltia-base' ),
+                'section' => 'veltia_header_section',
+            )
+        )
+    );
+
+    // CTA text color.
+    $wp_customize->add_setting(
+        'cta_color_text',
+        array(
+            'sanitize_callback' => 'sanitize_hex_color',
+        )
+    );
+    $wp_customize->add_control(
+        new WP_Customize_Color_Control(
+            $wp_customize,
+            'cta_color_text',
+            array(
+                'label'   => __( 'CTA Text Color', 'veltia-base' ),
+                'section' => 'veltia_header_section',
+            )
+        )
+    );
+
+    // Logo section.
+    $wp_customize->add_section(
+        'veltia_logo_section',
+        array(
+            'title'    => __( 'Logo', 'veltia-base' ),
+            'priority' => 31,
+        )
+    );
+
+    $wp_customize->add_setting(
+        'logo_max_height_header_desktop',
+        array(
+            'default'           => 56,
+            'sanitize_callback' => 'absint',
+        )
+    );
+    $wp_customize->add_control(
+        'logo_max_height_header_desktop',
+        array(
+            'label'   => __( 'Header Logo Max Height (Desktop, px)', 'veltia-base' ),
+            'section' => 'veltia_logo_section',
+            'type'    => 'number',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'logo_max_height_header_mobile',
+        array(
+            'default'           => 40,
+            'sanitize_callback' => 'absint',
+        )
+    );
+    $wp_customize->add_control(
+        'logo_max_height_header_mobile',
+        array(
+            'label'   => __( 'Header Logo Max Height (Mobile, px)', 'veltia-base' ),
+            'section' => 'veltia_logo_section',
+            'type'    => 'number',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'logo_max_width_header',
+        array(
+            'default'           => 200,
+            'sanitize_callback' => 'absint',
+        )
+    );
+    $wp_customize->add_control(
+        'logo_max_width_header',
+        array(
+            'label'   => __( 'Header Logo Max Width (px)', 'veltia-base' ),
+            'section' => 'veltia_logo_section',
+            'type'    => 'number',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'logo_max_height_slider',
+        array(
+            'default'           => 120,
+            'sanitize_callback' => 'absint',
+        )
+    );
+    $wp_customize->add_control(
+        'logo_max_height_slider',
+        array(
+            'label'   => __( 'Slider Logo Max Height (px)', 'veltia-base' ),
+            'section' => 'veltia_logo_section',
+            'type'    => 'number',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'logo_max_width_slider',
+        array(
+            'default'           => 300,
+            'sanitize_callback' => 'absint',
+        )
+    );
+    $wp_customize->add_control(
+        'logo_max_width_slider',
+        array(
+            'label'   => __( 'Slider Logo Max Width (px)', 'veltia-base' ),
+            'section' => 'veltia_logo_section',
+            'type'    => 'number',
+        )
+    );
+}
+
+/**
+ * Sanitize select fields.
+ *
+ * @param string               $input   Selected option.
+ * @param WP_Customize_Setting $setting Setting instance.
+ * @return string               Sanitized value.
+ */
+function veltia_sanitize_select( $input, $setting ) {
+    $input   = sanitize_text_field( $input );
+    $choices = array_keys( $setting->manager->get_control( $setting->id )->choices );
+    return in_array( $input, $choices, true ) ? $input : $setting->default;
+}
+
+add_action( 'customize_register', 'veltia_customize_register' );
+
+/*
+ * Example of using logo sizes in a slider template:
+ *
+ * <img class="slider-logo" src="<?php echo esc_url( $logo_url ); ?>" style="max-height:<?php echo esc_attr( get_theme_mod( 'logo_max_height_slider', 120 ) ); ?>px; max-width:<?php echo esc_attr( get_theme_mod( 'logo_max_width_slider', 300 ) ); ?>px;" alt="<?php esc_attr_e( 'Site logo', 'veltia-base' ); ?>">
+ */


### PR DESCRIPTION
## Summary
- add Customizer controls for header CTA and logo dimensions
- print header CTA with customizable styles and colors
- enqueue CTA styles and output logo dimensions via inline CSS

## Testing
- `php -l inc/customizer.php`
- `php -l functions.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e1d37fea483338a8bbe6a4caa3831