### PR TITLE
Use 'primary' as main menu location

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@ function mi_tema_setup() {
 
     // Menú principal
     register_nav_menus(array(
-        'menu-principal' => __('Menú Principal', 'veltia-base'),
+        'primary' => __('Menú Principal', 'veltia-base'),
     ));
 
     // Logo personalizado

--- a/header.php
+++ b/header.php
@@ -30,7 +30,7 @@
         <nav class="main-nav">
             <?php
             wp_nav_menu(array(
-                'theme_location' => 'menu-principal',
+                'theme_location' => 'primary',
                 'container'      => false,
                 'menu_class'     => 'nav-menu',
                 'fallback_cb'    => false


### PR DESCRIPTION
## Summary
- Rename registered menu slug from `menu-principal` to `primary`
- Update header to use `primary` menu location

## Testing
- `php -l functions.php`
- `php -l header.php`
- `npm test` *(fails: Could not read package.json)*

## Notes
After activating the theme, reassign the desired menu to the **Menú Principal** (`primary`) location in WordPress Appearance > Menus.

------
https://chatgpt.com/codex/tasks/task_e_689e2e7b41fc83339f61a51b5d14dd81