### PR TITLE
Fix header position and adjust body offset

### DIFF
--- a/js/header-scroll.js
+++ b/js/header-scroll.js
@@ -1,9 +1,25 @@
-document.addEventListener('DOMContentLoaded', function() {
-    window.addEventListener('scroll', function() {
+document.addEventListener('DOMContentLoaded', function () {
+    const header = document.querySelector('.site-header');
+
+    function adjustOffset() {
+        const height = header ? header.offsetHeight : 0;
+        document.body.style.paddingTop = height + 'px';
+    }
+
+    adjustOffset();
+    window.addEventListener('resize', adjustOffset);
+
+    window.addEventListener('scroll', function () {
         if (window.scrollY > 20) {
-            document.body.classList.add('scrolled');
+            if (!document.body.classList.contains('scrolled')) {
+                document.body.classList.add('scrolled');
+                adjustOffset();
+            }
         } else {
-            document.body.classList.remove('scrolled');
+            if (document.body.classList.contains('scrolled')) {
+                document.body.classList.remove('scrolled');
+                adjustOffset();
+            }
         }
     });
 });

--- a/style.css
+++ b/style.css
@@ -20,8 +20,9 @@ body {
 .site-header {
     width: 100%;
     padding: 1rem 0;
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
     z-index: 999;
     transition: all 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- use fixed positioning for the site header and ensure it spans full width at the top
- add JavaScript `adjustOffset` to pad the body based on header height and update on scroll and resize

## Testing
- `node --check js/header-scroll.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689e337ef03c83339e61a51c3cc1afea