### PR TITLE
Remove body padding offset from header scroll script

### DIFF
--- a/js/header-scroll.js
+++ b/js/header-scroll.js
@@ -1,25 +1,12 @@
 document.addEventListener('DOMContentLoaded', function () {
-    const header = document.querySelector('.site-header');
-
-    function adjustOffset() {
-        const height = header ? header.offsetHeight : 0;
-        document.body.style.paddingTop = height + 'px';
+    function updateHeaderOnScroll() {
+        if (window.scrollY > 20) {
+            document.body.classList.add('scrolled');
+        } else {
+            document.body.classList.remove('scrolled');
+        }
     }
 
-    adjustOffset();
-    window.addEventListener('resize', adjustOffset);
-
-    window.addEventListener('scroll', function () {
-        if (window.scrollY > 20) {
-            if (!document.body.classList.contains('scrolled')) {
-                document.body.classList.add('scrolled');
-                adjustOffset();
-            }
-        } else {
-            if (document.body.classList.contains('scrolled')) {
-                document.body.classList.remove('scrolled');
-                adjustOffset();
-            }
-        }
-    });
+    updateHeaderOnScroll();
+    window.addEventListener('scroll', updateHeaderOnScroll);
 });


### PR DESCRIPTION
## Summary
- remove adjustOffset and paddingTop manipulation so content scrolls behind fixed header
- retain `scrolled` class toggle for shrinking header on scroll

## Testing
- `node --check js/header-scroll.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689e358127f08333bee7fa8cf764b706