### PR TITLE
Add basic WordPress theme structure with header, footer, and hero

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,6 @@
+<footer class="site-footer">
+    <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,10 @@
+<?php
+function veltia_theme_scripts() {
+    wp_enqueue_style('veltia-style', get_stylesheet_uri(), [], '1.0');
+}
+add_action('wp_enqueue_scripts', 'veltia_theme_scripts');
+
+function veltia_theme_setup() {
+    add_theme_support('title-tag');
+}
+add_action('after_setup_theme', 'veltia_theme_setup');

--- a/header.php
+++ b/header.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="site-header">
+    <h1><a href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a></h1>
+</header>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,7 @@
+<?php get_header(); ?>
+
+<main id="primary" class="site-main">
+    <?php get_template_part('template-parts/hero'); ?>
+</main>
+
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+/*
+Theme Name: Veltia Basic Theme
+Theme URI: https://example.com/
+Author: OpenAI
+Description: Basic WordPress theme with header, footer, and hero section.
+Version: 1.0
+*/
+
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+
+.hero {
+    background: #f5f5f5;
+    padding: 60px 20px;
+    text-align: center;
+}
+
+.hero h2 {
+    margin: 0 0 10px;
+}
+
+.hero p {
+    margin: 0;
+}

--- a/template-parts/hero.php
+++ b/template-parts/hero.php
@@ -1,0 +1,4 @@
+<section class="hero">
+    <h2><?php bloginfo('description'); ?></h2>
+    <p>Esta es una seccion hero basica.</p>
+</section>


### PR DESCRIPTION
## Summary
- Add basic theme header, footer, and hero section
- Include minimal CSS and setup functions

## Testing
- `php -v`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689e3ba106fc83338899a3db9042db00