### PR TITLE
Add responsive header with navigation and CTA

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,10 +1,58 @@
 <?php
 function veltia_theme_scripts() {
     wp_enqueue_style('veltia-style', get_stylesheet_uri(), [], '1.0');
+    wp_enqueue_script('veltia-menu', get_template_directory_uri() . '/js/menu-toggle.js', [], '1.0', true);
 }
 add_action('wp_enqueue_scripts', 'veltia_theme_scripts');
 
 function veltia_theme_setup() {
     add_theme_support('title-tag');
+    add_theme_support('custom-logo', [
+        'height'      => 100,
+        'width'       => 400,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ]);
+    register_nav_menus([
+        'menu-principal' => __('Menú Principal', 'veltia'),
+    ]);
 }
 add_action('after_setup_theme', 'veltia_theme_setup');
+
+function veltia_theme_customize_register($wp_customize) {
+    $wp_customize->add_section('veltia_header', [
+        'title'    => __('Header', 'veltia'),
+        'priority' => 30,
+    ]);
+
+    $wp_customize->add_setting('cta_text', [
+        'default'           => __('Contáctanos', 'veltia'),
+        'sanitize_callback' => 'sanitize_text_field',
+    ]);
+    $wp_customize->add_control('cta_text', [
+        'label'   => __('Texto del botón CTA', 'veltia'),
+        'section' => 'veltia_header',
+        'type'    => 'text',
+    ]);
+
+    $wp_customize->add_setting('cta_link', [
+        'default'           => '#',
+        'sanitize_callback' => 'esc_url_raw',
+    ]);
+    $wp_customize->add_control('cta_link', [
+        'label'   => __('Enlace del botón CTA', 'veltia'),
+        'section' => 'veltia_header',
+        'type'    => 'url',
+    ]);
+
+    $wp_customize->add_setting('display_site_title', [
+        'default'           => true,
+        'sanitize_callback' => 'wp_validate_boolean',
+    ]);
+    $wp_customize->add_control('display_site_title', [
+        'label'   => __('Mostrar título del sitio si no hay logo', 'veltia'),
+        'section' => 'title_tagline',
+        'type'    => 'checkbox',
+    ]);
+}
+add_action('customize_register', 'veltia_theme_customize_register');

--- a/header.php
+++ b/header.php
@@ -5,7 +5,42 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php wp_head(); ?>
 </head>
+
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <header class="site-header">
-    <h1><a href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a></h1>
+    <div class="container">
+        <div class="site-branding">
+            <?php
+            if (function_exists('the_custom_logo') && has_custom_logo()) {
+                the_custom_logo();
+            } elseif (get_theme_mod('display_site_title', true)) {
+                ?>
+                <a href="<?php echo esc_url(home_url('/')); ?>" class="site-title"><?php bloginfo('name'); ?></a>
+                <?php
+            }
+            ?>
+        </div>
+
+        <button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">&#9776;</button>
+
+        <?php
+        wp_nav_menu([
+            'theme_location' => 'menu-principal',
+            'menu_id'        => 'primary-menu',
+            'container'      => 'nav',
+            'container_class'=> 'main-nav',
+        ]);
+        ?>
+
+        <?php
+        $cta_text = get_theme_mod('cta_text', '');
+        $cta_link = get_theme_mod('cta_link', '#');
+        if ($cta_text && $cta_link) {
+            ?>
+            <a class="menu-cta-button" href="<?php echo esc_url($cta_link); ?>"><?php echo esc_html($cta_text); ?></a>
+            <?php
+        }
+        ?>
+    </div>
 </header>

--- a/js/menu-toggle.js
+++ b/js/menu-toggle.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.querySelector('.menu-toggle');
+    const menu = document.querySelector('.main-nav');
+    if (toggle && menu) {
+        toggle.addEventListener('click', function () {
+            const expanded = this.getAttribute('aria-expanded') === 'true';
+            this.setAttribute('aria-expanded', !expanded);
+            menu.classList.toggle('open');
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ Version: 1.0
 
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 .hero {
@@ -23,4 +23,95 @@ body {
 
 .hero p {
     margin: 0;
+}
+
+:root {
+    --header-bg: #ffffff;
+    --header-text: #333333;
+    --cta-bg: #ff6600;
+    --cta-bg-hover: #e65c00;
+}
+
+.site-header {
+    background-color: var(--header-bg);
+    color: var(--header-text);
+}
+
+.site-header .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.site-branding .site-title {
+    font-weight: bold;
+    text-decoration: none;
+    color: var(--header-text);
+}
+
+.main-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 20px;
+}
+
+.main-nav a {
+    text-decoration: none;
+    color: var(--header-text);
+}
+
+.menu-cta-button {
+    background-color: var(--cta-bg);
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 4px;
+    text-decoration: none;
+    margin-left: 20px;
+}
+
+.menu-cta-button:hover {
+    background-color: var(--cta-bg-hover);
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--header-text);
+}
+
+@media (max-width: 768px) {
+    .site-header .container {
+        flex-wrap: wrap;
+    }
+    .menu-toggle {
+        display: block;
+        margin-left: auto;
+    }
+    .main-nav {
+        width: 100%;
+        display: none;
+        flex-direction: column;
+        margin-top: 20px;
+    }
+    .main-nav.open {
+        display: flex;
+    }
+    .main-nav ul {
+        flex-direction: column;
+        gap: 10px;
+    }
+    .menu-cta-button {
+        width: 100%;
+        text-align: center;
+        margin: 20px 0 0;
+    }
 }


### PR DESCRIPTION
## Summary
- Implement full-width responsive header with custom logo, navigation menu, and customizable CTA button.
- Register menu, custom logo support, and Customizer settings for CTA and site title visibility.
- Add CSS variables and responsive styles plus mobile menu toggle script.

## Testing
- `php -l header.php functions.php`

------
https://chatgpt.com/codex/tasks/task_e_689e3cf2b7848333a73166888172f873